### PR TITLE
plat-rcar: cpu-suspend: handle the power level

### DIFF
--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -52,12 +52,13 @@ static void main_tee_entry_fast(struct thread_smc_args *args)
 static unsigned long main_cpu_suspend(unsigned long a0,
 				unsigned long a1 __unused)
 {
+
 	uint32_t exceptions;
 
 	exceptions = cpu_spin_lock_xsave(&main_cpu_lock);
 	TMSG("a0=0x%lX, a1=0x%lX", a0, a1);
 
-	if (a0 == TFW_ARG_SYSTEM_SUSPEND) {
+	if (a0 >= TFW_ARG_SYSTEM_SUSPEND) {
 		if (suspend_to_ram_save_flag == 0U) {
 			suspend_to_ram_save();
 			suspend_to_ram_save_flag = 1U;


### PR DESCRIPTION
Signed-off-by: Jorge Ramirez-Ortiz <jramirez@baylibre.com>

This change will be required to support the upstream version of the rcar_gen3 TF-A  [1]

[1] https://github.com/ARM-software/arm-trusted-firmware/pull/1582